### PR TITLE
Fix for issue #5

### DIFF
--- a/lib/mongoid_geospatial/fields/point.rb
+++ b/lib/mongoid_geospatial/fields/point.rb
@@ -22,8 +22,7 @@ module Mongoid
 
         # Database -> Object
         def demongoize(object)
-          # return unless object && !object.empty?
-          Point.new(object[0], object[1])
+          Point.new(object[0], object[1]) rescue nil
         end
 
         def mongoize(object)


### PR DESCRIPTION
[issue #5](https://github.com/nofxx/mongoid_geospatial/issues/5) - rescue if the object is not in the expected [x,y] format
